### PR TITLE
[DPE-1052] Fixes for smoothly running spark-client CLI in the image

### DIFF
--- a/files/spark/bin/spark-client.pyspark
+++ b/files/spark/bin/spark-client.pyspark
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3 -m spark_client.cli.pyspark $*

--- a/files/spark/bin/spark-client.service-account-registry
+++ b/files/spark/bin/spark-client.service-account-registry
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3 -m spark_client.cli.service-account-registry $*

--- a/files/spark/bin/spark-client.spark-shell
+++ b/files/spark/bin/spark-client.spark-shell
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3 -m spark_client.cli.spark-shell $*

--- a/files/spark/bin/spark-client.spark-submit
+++ b/files/spark/bin/spark-client.spark-submit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3 -m spark_client.cli.spark-submit $*

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -13,8 +13,8 @@ entrypoint: ["/bin/bash", "/opt/pebble-start.sh"]
 env:
   - SPARK_HOME: /opt/spark
   - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-  - PYTHONPATH: /opt/spark/python:/opt/spark/python/build:/opt/spark/bin:$SNAP/usr/lib/python3/dist-packages:/opt/spark/python/dist:$PYTHONPATH
-  - PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark:/opt/spark/bin
+  - PYTHONPATH: /opt/spark/python:/opt/spark/python/dist:/usr/lib/python3/dist-packages
+  - PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark:/opt/spark/bin:/opt/spark/python/bin
   - HOME: /home/spark
 
 parts:
@@ -111,6 +111,21 @@ parts:
       pip install --target=${CRAFT_PART_INSTALL}/opt/spark/python/dist ./spark_client-${SPARK_CLIENT_PKG_VERSION}-py3-none-any.whl
     stage:
       - opt/spark/python/dist
+
+  spark-client-apps:
+    plugin: dump
+    after: [ client-scripts ]
+    source: files/spark/bin
+    organize:
+      spark-client.pyspark: opt/spark/python/bin/spark-client.pyspark
+      spark-client.service-account-registry: opt/spark/python/bin/spark-client.service-account-registry
+      spark-client.spark-shell: opt/spark/python/bin/spark-client.spark-shell
+      spark-client.spark-submit: opt/spark/python/bin/spark-client.spark-submit
+    stage:
+      - opt/spark/python/bin/spark-client.pyspark
+      - opt/spark/python/bin/spark-client.service-account-registry
+      - opt/spark/python/bin/spark-client.spark-shell
+      - opt/spark/python/bin/spark-client.spark-submit
 
   kubectl-bin:
     plugin: nil


### PR DESCRIPTION
While testing the spark client to be running smoothly on OCI, I noticed that 

1. The PYTHONPATH and PATH definition could be improved
2. We did not have a snap-like user experience with the snap entrypoints, which I have rendered using some simple bash files (not sure this is the right way to do that, but it seems to work) 