### PR TITLE
Updating spark version manually to 3.3.2.

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@ summary: Spark ROCK
 description: Spark ROCK
 license: Apache-2.0
 
-version: "3.3.1"
+version: "3.3.2"
 base: ubuntu:22.04
 platforms:
   amd64:
@@ -21,8 +21,8 @@ parts:
 
   spark:
     plugin: dump
-    source: https://downloads.apache.org/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz
-    source-checksum: sha512/769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff
+    source: https://downloads.apache.org/spark/spark-3.3.2/spark-3.3.2-bin-hadoop3.tgz
+    source-checksum: sha512/4cd2396069fbe0f8efde2af4fd301bf46f8c6317e9dea1dd42a405de6a38380635d49b17972cb92c619431acece2c3af4c23bfdf193cedb3ea913ed69ded23a1
     overlay-script: |
       set -ex
       sed -i 's/http:\/\/deb.\(.*\)/https:\/\/deb.\1/g' /etc/apt/sources.list


### PR DESCRIPTION
Spark updates are not automated for the rock currently. 

For now, updating the version manually.