### PR TITLE
[DPE-2162] Improve Pebble entrypoint integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE=base-charmed-spark:latest
+FROM $BASE_IMAGE
+# Provide Default Entrypoint for Pebble
+ENTRYPOINT [ "/bin/pebble", "enter", "--verbose", "--args", "entrypoint" ]

--- a/files/spark/bin/charmed-spark-entrypoint.sh
+++ b/files/spark/bin/charmed-spark-entrypoint.sh
@@ -1,24 +1,20 @@
 #!/bin/bash
 
-TYPE=$1
+FLAVOUR=$1
 
-echo "Running script with ${TYPE} flavour"
+echo "Running script with ${FLAVOUR} flavour"
 
-case "${TYPE}" in
+case "${FLAVOUR}" in
   driver|executor)
-    cd /opt/spark
-    ./entrypoint.sh $*
-    ;;
-  history-server)
-    cd /opt/spark
-    ./sbin/start-history-server.sh --properties-file ${SPARK_PROPERTIES_FILE}
+    pushd /opt/spark
+    ./entrypoint.sh "$@"
     ;;
   "")
-    # Infinite loop to allow pebble to be running indefinitely
-    while true; do sleep 5; done
+    # Infinite sleep to allow pebble to be running indefinitely
+    sleep inf
     ;;
   *)
-    echo "Component \"${TYPE}\" unknown"
+    echo "Component \"${FLAVOUR}\" unknown"
     exit 1
     ;;
 esac

--- a/files/spark/bin/charmed-spark-entrypoint.sh
+++ b/files/spark/bin/charmed-spark-entrypoint.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
-# This script still exists because passing of working directory to services has not yet landed
-# in Pebble (https://github.com/canonical/pebble/issues/158) and being in the write directory
-# is important for the entrypoint script
+TYPE=$1
 
-cd /opt/spark
+echo "Running script with ${TYPE} flavour"
 
-./entrypoint.sh $*
+case "${TYPE}" in
+  driver|executor)
+    cd /opt/spark
+    ./entrypoint.sh $*
+    ;;
+  history-server)
+    cd /opt/spark
+    ./sbin/start-history-server.sh --properties-file ${SPARK_PROPERTIES_FILE}
+    ;;
+  "")
+    # Infinite loop to allow pebble to be running indefinitely
+    while true; do sleep 5; done
+    ;;
+  *)
+    echo "Component \"${TYPE}\" unknown"
+    exit 1
+    ;;
+esac

--- a/files/spark/conf/podTemplate.yaml
+++ b/files/spark/conf/podTemplate.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: spark
-    args: ["--args", "spark-entrypoint"]

--- a/files/spark/conf/spark-defaults.conf
+++ b/files/spark/conf/spark-defaults.conf
@@ -1,3 +1,1 @@
 spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:3.4.0-22.04_edge
-spark.kubernetes.driver.podTemplateFile=/etc/spark/conf/podTemplate.yaml
-spark.kubernetes.executor.podTemplateFile=/etc/spark/conf/podTemplate.yaml

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -9,7 +9,7 @@ platforms:
   amd64:
 
 services:
-  spark-entrypoint:
+  entrypoint:
     command: "/bin/bash /opt/pebble/charmed-spark-entrypoint.sh"
     summary: "This is the service to startup Spark processes using the Spark entrypoint"
     override: replace
@@ -25,6 +25,21 @@ services:
       SPARK_USER_DATA: /home/spark
     on-success: shutdown
     on-failure: shutdown
+  history-server:
+    command: "/bin/bash /opt/pebble/charmed-spark-entrypoint.sh history-server"
+    summary: "This is the Spark History Server service"
+    override: replace
+    startup: disabled
+    environment:
+      SPARK_HOME: /opt/spark
+      SPARK_CONFS: /etc/spark8t/conf
+      JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+      PYTHONPATH: /opt/spark/python:/opt/spark8t/python/dist:/usr/lib/python3/dist-packages
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark:/opt/spark/bin:/opt/spark/python/bin:/opt/spark-client/python/bin
+      HOME: /home/spark
+      KUBECONFIG: /home/spark/.kube/config
+      SPARK_USER_DATA: /home/spark
+      SPARK_PROPERTIES_FILE: /etc/spark/conf/spark-defaults.conf
 
 parts:
   spark:
@@ -136,7 +151,6 @@ parts:
     source: files/spark
     organize:
       conf/spark-defaults.conf: etc/spark8t/conf/spark-defaults.conf
-      conf/podTemplate.yaml: etc/spark/conf/podTemplate.yaml
       bin/charmed-spark-entrypoint.sh: opt/pebble/charmed-spark-entrypoint.sh
       bin/spark-client.pyspark: opt/spark-client/python/bin/spark-client.pyspark
       bin/spark-client.service-account-registry: opt/spark-client/python/bin/spark-client.service-account-registry
@@ -144,7 +158,6 @@ parts:
       bin/spark-client.spark-submit: opt/spark-client/python/bin/spark-client.spark-submit
     stage:
       - etc/spark8t/conf/
-      - etc/spark/conf/podTemplate.yaml
       - opt/pebble/charmed-spark-entrypoint.sh
       - opt/spark-client/python/bin/spark-client.pyspark
       - opt/spark-client/python/bin/spark-client.service-account-registry

--- a/tests/integration/integration-tests.sh
+++ b/tests/integration/integration-tests.sh
@@ -63,9 +63,11 @@ cleanup_user() {
   kubectl exec testpod -- env UU="$USERNAME" NN="$NAMESPACE" \
                   /bin/bash -c 'spark-client.service-account-registry delete --username $UU --namespace $NN'  
 
-  account_not_found_counter=$(kubectl exec testpod -- env UU="$USERNAME" NN="$NAMESPACE" /bin/bash -c 'spark-client.service-account-registry get-config --username=$UU --namespace $NN' 2>&1 | grep -c 'NotFound')
+  OUTPUT=$(kubectl exec testpod -- /bin/bash -c 'spark-client.service-account-registry list')
 
-  if [ "${account_not_found_counter}" == "0" ]; then
+  EXISTS=$(echo -e "$OUTPUT" | grep "$NAMESPACE:$USERNAME" | wc -l)
+
+  if [ "$EXISTS" != "0" ]; then
       exit 2
   fi
 
@@ -99,7 +101,7 @@ setup_test_pod() {
         break
     elif [ "${i}" -le "5" ]
     then
-        echo "HERE"
+        echo "Waiting the pod to come online..."
         sleep 5
     else
         echo "testpod did not come up. Test Failed!"

--- a/tests/integration/integration-tests.sh
+++ b/tests/integration/integration-tests.sh
@@ -101,7 +101,7 @@ setup_test_pod() {
         break
     elif [ "${i}" -le "5" ]
     then
-        echo "Waiting the pod to come online..."
+        echo "Waiting for the pod to come online..."
         sleep 5
     else
         echo "testpod did not come up. Test Failed!"

--- a/tests/integration/integration-tests.sh
+++ b/tests/integration/integration-tests.sh
@@ -67,13 +67,13 @@ cleanup_user() {
 
   EXISTS=$(echo -e "$OUTPUT" | grep "$NAMESPACE:$USERNAME" | wc -l)
 
-  if [ "$EXISTS" != "0" ]; then
+  if [ "${EXISTS}" -ne "0" ]; then
       exit 2
   fi
 
   kubectl delete namespace ${NAMESPACE}
 
-  if [ "${EXIT_CODE}" != "0" ]; then
+  if [ "${EXIT_CODE}" -ne "0" ]; then
       exit 1
   fi
 }
@@ -91,6 +91,7 @@ cleanup_user_failure() {
 setup_test_pod() {
   kubectl apply -f ./tests/integration/resources/testpod.yaml
 
+  SLEEP_TIME=1
   for i in {1..5}
   do
     pod_status=$(kubectl get pod testpod | awk '{ print $3 }' | tail -n 1)
@@ -102,11 +103,12 @@ setup_test_pod() {
     elif [ "${i}" -le "5" ]
     then
         echo "Waiting for the pod to come online..."
-        sleep 5
+        sleep $SLEEP_TIME
     else
         echo "testpod did not come up. Test Failed!"
         exit 3
     fi
+    SLEEP_TIME=$(expr $SLEEP_TIME \* 2);
   done
 
   MY_KUBE_CONFIG=$(cat /home/${USER}/.kube/config)

--- a/tests/integration/resources/testpod.yaml
+++ b/tests/integration/resources/testpod.yaml
@@ -8,8 +8,6 @@ spec:
     name: spark
     ports:
     - containerPort: 18080
-    command: ["sleep"]
-    args: ["3600"]
     env:
       - name: SPARK_CONFS
         value: /etc/spark8t/conf

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,15 @@ commands =
 	bash -ec 'if ! [ -f {env:name}_$(yq .version rockcraft.yaml)_amd64.rock ]; \
 		then rockcraft pack; fi'
 
-	bash -ec 'microk8s ctr image import {env:name}_$(yq .version rockcraft.yaml)_amd64.rock --base-name {env:registry_namespace}/{env:test-name}'
+    # ==========
+	# Workaround
+	# ==========
+	# bash -ec 'microk8s ctr image import {env:name}_$(yq .version rockcraft.yaml)_amd64.rock --base-name {env:registry_namespace}/{env:test-name}'
+	# ==========
+	bash -ec 'skopeo --insecure-policy copy oci-archive:"{env:name}_$(yq .version rockcraft.yaml)_amd64.rock" docker-daemon:"charmed-spark:pre"'
+	bash -ec 'docker build - -t {env:registry_namespace}/{env:test-name}:$(yq .version rockcraft.yaml) --build-arg BASE_IMAGE=charmed-spark:pre < Dockerfile'
+	bash -ec 'docker save {env:registry_namespace}/{env:test-name} > /tmp/tmp.tar'
+	bash -ec 'microk8s ctr image import - --base-name {env:registry_namespace}/{env:test-name}:$(yq .version rockcraft.yaml) < /tmp/tmp.tar'
+	# ==========
 
 	bash {toxinidir}/tests/integration/integration-tests.sh


### PR DESCRIPTION
The PR provides a unified image for running both services and spark-jobs. To do so, the entrypoint of the Rock image, generated by rockcraft, is overridden to add a default pebble services using `--args service` pebble command argument. This allow to retrain the UX (or similarly using pod manifests)

```docker run charmed-spark driver <extra-args>```

The rockcraft pebble specification provides two services:
* **entrypoint** connected to a general entrypoint that can be used to run the image with different flavour:
```docker run charmed-spark driver|executor|history-server```
If no arguments are passed, the entrypoint (which MUST be enabled by default) results in an infinite loop, thus allowing to have the image running with pebble daemon up and running (This also helps to avoid erroring out when starting the image in the charm, where Pebble is started - and therefore the default service - possibly before overriding a plan)
*  **history-server** connected to a preferred way for running history-server as a proper pebble service. This will be used (and partially overridden) in the charm. 


