### PR TITLE
[MISC] Version bump of binaries with 3.4.1-ubuntu2

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -118,7 +118,6 @@ parts:
       - python3-pip
     overlay-script: |
       mkdir -p $CRAFT_PART_INSTALL/opt/spark8t/python/dist
-      pip install --upgrade pip setuptools
       pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist  https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.1/spark8t-0.0.1-py3-none-any.whl
     stage:
       - opt/spark8t/python/dist
@@ -176,7 +175,6 @@ parts:
       - libnss3
       - procps
       - openjdk-11-jre-headless
-      - python3-setuptools
 
     override-prime: |
       # Please refer to https://discourse.ubuntu.com/t/unifying-user-identity-across-snaps-and-rocks/36469

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -42,8 +42,8 @@ services:
 parts:
   spark:
     plugin: dump
-    source: https://github.com/welpaolo/test-actions/releases/download/spark-3.4.1/spark-3.4.1-bin-ubuntu1-20230831140746.tgz
-    source-checksum: sha512/dfd6b0c4f00abc800ab301773b577828f5121ac283446c2d355c1c29dc3db1b0122aea94fce8399cd284b9f35522cec11dc643fee27ebf878937e965632f1931
+    source: https://github.com/welpaolo/test-actions/releases/download/spark-3.4.1/spark-3.4.1-bin-ubuntu2-20230906081911.tgz
+    source-checksum: sha512/409b8d1a07f51e1c2c1d7f8acbcf532e113162fea41c3f2a7fe042db998cb281364ebe04c474079b3aaa6fb980018b075cbb987949f0145474a1524b310ac461
     overlay-script: |
       sed -i 's/http:\/\/deb.\(.*\)/https:\/\/deb.\1/g' /etc/apt/sources.list
       apt-get update
@@ -118,6 +118,7 @@ parts:
       - python3-pip
     overlay-script: |
       mkdir -p $CRAFT_PART_INSTALL/opt/spark8t/python/dist
+      pip install --upgrade pip setuptools
       pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist  https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.1/spark8t-0.0.1-py3-none-any.whl
     stage:
       - opt/spark8t/python/dist


### PR DESCRIPTION
This new artifact should fix:
* orc from 1.8.4 to 1.9.1
* janino from 3.1.9 to 3.1.10

see [here](https://git.launchpad.net/soss/+source/charmed-spark/commit/?id=07cd8772805238a69ecd9a70bb8e3c9c4982d8b2) for more details