### PR TITLE
[DPE-4993] Fix release pipeline for GPU image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Setup LXD
         uses: canonical/setup-lxd@main
+        with:
+          channel: 5.21/stable
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build_gpu.yaml
+++ b/.github/workflows/build_gpu.yaml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Setup LXD
         uses: canonical/setup-lxd@main
+        with:
+          channel: 5.21/stable
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -62,8 +62,9 @@ jobs:
     
     - name: Install required packages/snaps
       run: |
-        sudo snap install yq
+        sudo apt-get update
         sudo apt-get install build-essential -yqq
+        sudo snap install yq
 
     - name: Get Artifact Name
       id: artifact

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -213,6 +213,8 @@ jobs:
           TRACK=${{ needs.release_checks.outputs.track }}
           if [ ! -z "$RISK" ] && [ "${RISK}" != "no-risk" ]; then TAG=${TRACK}_${RISK}; else TAG=${TRACK}; fi
       
+          IMAGE_NAME=$(make help REPOSITORY=${REPOSITORY} TAG=${TAG} FLAVOUR=spark-gpu help | grep "Image\:" | cut -d ":" -f2  | xargs)
+
           # Import artifact into docker with new tag
           sudo make docker-import \
             FLAVOUR=spark-gpu \

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ AZURE_MARKER=$(_MAKE_DIR)/azure.tag
 # The names of different flavours of the image in the docker container registry
 STAGED_IMAGE_DOCKER_ALIAS=staged-charmed-spark:latest
 SPARK_DOCKER_ALIAS=charmed-spark:$(SPARK_VERSION)
-SPARK_GPU_DOCKER_ALIAS=charmed-spark:$(SPARK_VERSION)
+SPARK_GPU_DOCKER_ALIAS=charmed-spark-gpu:$(SPARK_VERSION)
 JUPYTER_DOCKER_ALIAS=charmed-spark-jupyter:$(SPARK_VERSION)-$(JUPYTER_VERSION)
 KYUUBI_DOCKER_ALIAS=charmed-spark-kyuubi:$(SPARK_VERSION)-$(KYUUBI_VERSION)
 
@@ -192,11 +192,11 @@ $(SPARK_MARKER): $(ROCK_FILE) images/charmed-spark/Dockerfile
           oci-archive:"$(ROCK_FILE)" \
           docker-daemon:"$(STAGED_IMAGE_DOCKER_ALIAS)"
 
-	docker build -t $(SPARK_GPU_DOCKER_ALIAS) \
+	docker build -t $(SPARK_DOCKER_ALIAS) \
 		--build-arg BASE_IMAGE="$(STAGED_IMAGE_DOCKER_ALIAS)" \
 		images/charmed-spark-gpu
 
-	docker save $(SPARK_GPU_DOCKER_ALIAS) -o $(SPARK_ARTIFACT)
+	docker save $(SPARK_DOCKER_ALIAS) -o $(SPARK_ARTIFACT)
 
 	touch $(SPARK_MARKER)
 


### PR DESCRIPTION
This PR addresses some issues with publishing the GPU image on GHCR. 

* While addressing the issue, some fixes and small typos in the Makefile were found and fixed. 
* Because of some breaking changes in LXD, it was required to downgrade the LXD channel to `5.21/stable` (see matrix conversation [here](https://matrix.to/#/!NPPCseDHKRvSBMUEXN:ubuntu.com/$Y-rD0RdB2Jnj6rQbY1DYj4SuGFPd9rguzpL-JCdkguQ?via=ubuntu.com&via=matrix.org))

The publishing of the image was tested [here](https://github.com/deusebio/charmed-spark-rock/actions/runs/10216180428).