### PR TITLE
[MISC] Fix tag version for GPU image

### DIFF
--- a/.github/workflows/build_gpu.yaml
+++ b/.github/workflows/build_gpu.yaml
@@ -37,12 +37,12 @@ jobs:
           sudo snap install rockcraft --classic --edge    
       
       - name: Build image (GPU)
-        run: sudo make build FLAVOUR=spark-gpu
+        run: sudo make build FLAVOUR=gpu
 
       - name: Get Artifact Name
         id: artifact
         run: |
-          GPU_ARTIFACT=$(make help FLAVOUR=spark-gpu | grep 'Artifact: ')
+          GPU_ARTIFACT=$(make help FLAVOUR=gpu | grep 'Artifact: ')
           echo "gpu_artifact_name=${GPU_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
 
       - name: Change artifact permissions

--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -69,7 +69,7 @@ jobs:
     - name: Get Artifact Name
       id: artifact
       run: |
-        GPU_ARTIFACT=$(make help FLAVOUR=spark-gpu | grep 'Artifact: ')
+        GPU_ARTIFACT=$(make help FLAVOUR=gpu | grep 'Artifact: ')
         echo "gpu_artifact_name=${GPU_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
 
     - name: Download artifact
@@ -84,7 +84,7 @@ jobs:
         mv charmed-spark/${{ steps.artifact.outputs.gpu_artifact_name }} .
         touch .make_cache/k8s.tag
         # Import artifact into microk8s to be used in integration tests
-        sudo make microk8s-import FLAVOUR=spark-gpu PREFIX=test- REPOSITORY=ghcr.io/canonical/ \
+        sudo make microk8s-import FLAVOUR=gpu PREFIX=test- REPOSITORY=ghcr.io/canonical/ \
           -o ${{ steps.artifact.outputs.gpu_artifact_name }}
 
     - name: Run integration tests on GPU

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -36,7 +36,7 @@ jobs:
           echo "jupyter_artifact_name=${JUPYTER_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
           KYUUBI_ARTIFACT=$(make help FLAVOUR=kyuubi | grep 'Artifact: ')
           echo "kyuubi_artifact_name=${KYUUBI_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
-          GPU_ARTIFACT=$(make help FLAVOUR=spark-gpu | grep 'Artifact: ')
+          GPU_ARTIFACT=$(make help FLAVOUR=gpu | grep 'Artifact: ')
           echo "gpu_artifact_name=${GPU_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
 
       - name: Install and configure microk8s

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -78,7 +78,7 @@ jobs:
           echo "jupyter_artifact_name=${JUPYTER_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
           KYUUBI_ARTIFACT=$(make help FLAVOUR=kyuubi | grep 'Artifact: ')
           echo "kyuubi_artifact_name=${KYUUBI_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
-          GPU_ARTIFACT=$(make help FLAVOUR=spark-gpu | grep 'Artifact: ')
+          GPU_ARTIFACT=$(make help FLAVOUR=gpu | grep 'Artifact: ')
           echo "gpu_artifact_name=${GPU_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
 
       - name: Download artifact
@@ -213,11 +213,11 @@ jobs:
           TRACK=${{ needs.release_checks.outputs.track }}
           if [ ! -z "$RISK" ] && [ "${RISK}" != "no-risk" ]; then TAG=${TRACK}_${RISK}; else TAG=${TRACK}; fi
       
-          IMAGE_NAME=$(make help REPOSITORY=${REPOSITORY} TAG=${TAG} FLAVOUR=spark-gpu help | grep "Image\:" | cut -d ":" -f2  | xargs)
+          IMAGE_NAME=$(make help REPOSITORY=${REPOSITORY} TAG=${TAG} FLAVOUR=gpu help | grep "Image\:" | cut -d ":" -f2  | xargs)
 
           # Import artifact into docker with new tag
           sudo make docker-import \
-            FLAVOUR=spark-gpu \
+            FLAVOUR=gpu \
             REPOSITORY=${REPOSITORY} \
             TAG=${TAG} \
             -o ${{ steps.artifact.outputs.gpu_artifact_name }}
@@ -232,7 +232,7 @@ jobs:
           docker push ${IMAGE_NAME}:${TAG}
       
           if [[ "$RISK" == "edge" ]]; then
-            VERSION_LONG=$(make help FLAVOUR=spark-gpu | grep "Tag\:" | cut -d ":" -f2  | xargs)
+            VERSION_LONG=$(make help FLAVOUR=gpu | grep "Tag\:" | cut -d ":" -f2  | xargs)
             VERSION_TAG="${VERSION_LONG}-${{ needs.release_checks.outputs.base }}_edge"
       
             docker tag ${IMAGE_NAME}:${TAG} ${IMAGE_NAME}:${VERSION_TAG}

--- a/images/metadata.yaml
+++ b/images/metadata.yaml
@@ -12,3 +12,13 @@ flavours:
     image_description: |
       This is an OCI image that contains Kyuubi, fully integrated with Charmed
       Spark ecosystem and utilities.
+  gpu:
+    version: 24.04.1
+    image_description: |
+      This is an OCI image that bundles Apache Spark binaries together with other
+      tools of its ecosystem in order to be used in Charmed Operators, providing
+      an automated and seamless experience to deploy, operate, manage and monitor
+      SparkJob on K8s cluster.
+      This image includes support for Nvidia Spark Rapids.
+      It is an open source, end-to-end, production ready data platform on top of
+      cloud native technologies.


### PR DESCRIPTION
We have noticed that the GPU tag does not use the tag versioning we have for jupyter and kyuubi. I have update this. 

Also while doing this, I changed the `FLAVOUR` for gpu support from `spark-gpu` to `gpu` which obeys less is more principle, and it seems a bit more consistent with the other flavours that we have, like naming `charmed-spark-{flavour}` the images