### PR TITLE
Add log forwarding Pebble layer to sparkd

### DIFF
--- a/images/charmed-spark/bin/sparkd.sh
+++ b/images/charmed-spark/bin/sparkd.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 
 function get_log_layer {
-  LOG_LAYER_FILE="/opt/pebble/log-layer.yaml"
-  ESCAPED_LOKI_URL="$(<<< "$LOKI_URL" sed -e 's`[][\\/.*^$]`\\&`g')"
-  sed -e "s/\$LOKI_URL/$ESCAPED_LOKI_URL/g" \
+  local loki_url=$1
+  local log_layer_file=${2-"/opt/pebble/log-layer.yaml"}
+  sed -e "s/\$LOKI_URL/$loki_url/g" \
+      -e "s/\$FLAVOUR/$FLAVOUR/g" \
       -e "s/\$SPARK_APPLICATION_ID/$SPARK_APPLICATION_ID/g" \
       -e "s/\$SPARK_USER/$SPARK_USER/g" \
-      -e "s/\$SPARK_EXECUTOR_POD_NAME/$SPARK_EXECUTOR_POD_NAME/g" \
-      $LOG_LAYER_FILE
+      -e "s/\$HOSTNAME/$HOSTNAME/g" \
+      $log_layer_file
+}
+
+function log_forwarding {
+  # We need to escape special characters from URL to be able to use with template.
+  local loki_url="$(<<< "$LOKI_URL" sed -e 's`[][\\/.*^$]`\\&`g')"
+  if [ ! -z "$loki_url" ]; then
+      echo "Log-forwarding to Loki is enabled."
+      local rendered_log_layer=$(get_log_layer $loki_url)
+      echo "$rendered_log_layer" | tee /tmp/rendered_log_layer.yaml
+      pebble add logging /tmp/rendered_log_layer.yaml
+  else
+      echo "Log-forwarding to Loki is disabled."
+  fi
 }
 
 function finish {
@@ -19,22 +33,13 @@ function finish {
 }
 trap finish EXIT
 
-if [ ! -z "${LOKI_URL}" ]
-then
-    echo "Configuring log-forwarding to Loki."
-    RENDERED_LOG_LAYER=$(get_log_layer)
-    echo "$RENDERED_LOG_LAYER" | tee /tmp/rendered_log_layer.yaml
-    pebble add logging /tmp/rendered_log_layer.yaml
-else
-    echo "Log-forwarding to Loki is disabled."
-fi
-
 FLAVOUR=$1
 
 echo "Running script with ${FLAVOUR} flavour"
 
 case "${FLAVOUR}" in
   driver|executor)
+    log_forwarding
     pushd /opt/spark
     ./entrypoint.sh "$@"
     ;;

--- a/images/charmed-spark/pebble/log-layer.yaml
+++ b/images/charmed-spark/pebble/log-layer.yaml
@@ -6,7 +6,8 @@ log-targets:
     services: [all]
     labels:
       product: charmed-spark
+      flavour: $FLAVOUR
       app: spark
       app_id: $SPARK_APPLICATION_ID
       user: $SPARK_USER
-      pod: $SPARK_EXECUTOR_POD_NAME
+      hostname: $HOSTNAME

--- a/images/charmed-spark/pebble/log-layer.yaml
+++ b/images/charmed-spark/pebble/log-layer.yaml
@@ -6,8 +6,8 @@ log-targets:
     services: [all]
     labels:
       product: charmed-spark
-      flavour: $FLAVOUR
+      role: $FLAVOUR
       app: spark
-      app_id: $SPARK_APPLICATION_ID
+      spark_job_id: $SPARK_APPLICATION_ID
       user: $SPARK_USER
       hostname: $HOSTNAME

--- a/images/charmed-spark/pebble/log-layer.yaml
+++ b/images/charmed-spark/pebble/log-layer.yaml
@@ -1,0 +1,12 @@
+log-targets:
+  grafana-agent-k8s:
+    override: replace
+    type: loki
+    location: $LOKI_URL
+    services: [all]
+    labels:
+      product: charmed-spark
+      app: spark
+      app_id: $SPARK_APPLICATION_ID
+      user: $SPARK_USER
+      pod: $SPARK_EXECUTOR_POD_NAME

--- a/images/charmed-spark/pebble/log-layer.yaml
+++ b/images/charmed-spark/pebble/log-layer.yaml
@@ -10,4 +10,4 @@ log-targets:
       app: spark
       spark_job_id: $SPARK_APPLICATION_ID
       user: $SPARK_USER
-      hostname: $HOSTNAME
+      pod: $HOSTNAME

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -182,6 +182,7 @@ parts:
       bin/spark-client.service-account-registry: opt/spark-client/python/bin/spark-client.service-account-registry
       bin/spark-client.spark-shell: opt/spark-client/python/bin/spark-client.spark-shell
       bin/spark-client.spark-submit: opt/spark-client/python/bin/spark-client.spark-submit
+      pebble/log-layer.yaml: opt/pebble/log-layer.yaml
     stage:
       - etc/spark8t/conf/
       - etc/spark/conf/
@@ -192,6 +193,7 @@ parts:
       - opt/spark-client/python/bin/spark-client.service-account-registry
       - opt/spark-client/python/bin/spark-client.spark-shell
       - opt/spark-client/python/bin/spark-client.spark-submit
+      - opt/pebble/log-layer.yaml
 
   user-setup:
     plugin: nil

--- a/tests/integration/integration-tests.sh
+++ b/tests/integration/integration-tests.sh
@@ -53,6 +53,16 @@ validate_metrics() {
   fi
 }
 
+validate_logs() {
+  log=$1
+  if [ $(grep -Ri "Configuring log-forwarding to Loki." $log | wc -l) -lt 2 ]; then
+    exit 1
+  fi
+  if [ $(grep -Ri 'Layer \\\\"logging\\\\" added successfully from \\\\"/tmp/rendered_log_layer.yaml\\\\"' $log | wc -l) -lt 2 ]; then
+    exit 1
+  fi
+}
+
 setup_user() {
   echo "setup_user() ${1} ${2}"
 
@@ -422,6 +432,55 @@ run_example_job_in_pod_with_metrics() {
 }
 
 
+run_example_job_in_pod_with_log_forwarding() {
+  NAMESPACE=${1-$NAMESPACE}
+  USERNAME=${2-spark}
+  SPARK_EXAMPLES_JAR_NAME="spark-examples_2.12-$(get_spark_version).jar"
+
+  PREVIOUS_JOB=$(kubectl -n $NAMESPACE get pods --sort-by=.metadata.creationTimestamp | grep driver | tail -n 1 | cut -d' ' -f1)
+  # start simple http server
+  LOG_FILE="/tmp/server.log"
+  SERVER_PORT=9091
+  python3 tests/integration/resources/test_web_server.py $SERVER_PORT > $LOG_FILE &
+  HTTP_SERVER_PID=$!
+  # get ip address
+  IP_ADDRESS=$(hostname -I | cut -d ' ' -f 1)
+  echo "IP: $IP_ADDRESS"
+
+  kubectl -n $NAMESPACE exec testpod -- env PORT="$SERVER_PORT" IP="$IP_ADDRESS" UU="$USERNAME" NN="$NAMESPACE" JJ="$SPARK_EXAMPLES_JAR_NAME" IM="$(spark_image)" \
+                  /bin/bash -c 'spark-client.spark-submit \
+                  --username $UU --namespace $NN \
+                  --conf spark.kubernetes.driver.request.cores=100m \
+                  --conf spark.kubernetes.executor.request.cores=100m \
+                  --conf spark.kubernetes.container.image=$IM \
+                  --conf spark.executorEnv.LOKI_URL="$IP:$PORT" \
+                  --class org.apache.spark.examples.SparkPi \
+                  local:///opt/spark/examples/jars/$JJ 1000'
+
+  # kubectl --kubeconfig=${KUBE_CONFIG} get pods
+  DRIVER_PODS=$(kubectl get pods --sort-by=.metadata.creationTimestamp -n ${NAMESPACE} | grep driver )
+  DRIVER_JOB=$(kubectl get pods --sort-by=.metadata.creationTimestamp -n ${NAMESPACE} | grep driver | tail -n 1 | cut -d' ' -f1)
+
+  if [[ "${DRIVER_JOB}" == "${PREVIOUS_JOB}" ]]
+  then
+    echo "ERROR: Sample job has not run!"
+    exit 1
+  fi
+
+  # Check job output
+  # Sample output
+  # "Pi is roughly 3.13956232343"
+  pi=$(kubectl logs $(kubectl get pods --sort-by=.metadata.creationTimestamp -n ${NAMESPACE} | grep driver | tail -n 1 | cut -d' ' -f1)  -n ${NAMESPACE} | grep 'Pi is roughly' | rev | cut -d' ' -f1 | rev | cut -c 1-3)
+  echo -e "Spark Pi Job Output: \n ${pi}"
+
+  validate_pi_value $pi
+  validate_logs $LOG_FILE
+
+  # kill http server
+  kill $HTTP_SERVER_PID
+}
+
+
 run_example_job_with_error_in_pod() {
   SPARK_EXAMPLES_JAR_NAME="spark-examples_2.12-$(get_spark_version).jar"
 
@@ -656,6 +715,12 @@ echo -e "RUN EXAMPLE JOB WITH PROMETHEUS METRICS"
 echo -e "########################################"
 
 (setup_user_context && test_example_job_in_pod_with_metrics && cleanup_user_success) || cleanup_user_failure_in_pod
+
+echo -e "########################################"
+echo -e "RUN EXAMPLE JOB WITH LOG FORWARDING"
+echo -e "########################################"
+
+(setup_user_context && run_example_job_in_pod_with_log_forwarding && cleanup_user_success) || cleanup_user_failure_in_pod
 
 echo -e "########################################"
 echo -e "RUN EXAMPLE JOB WITH ERRORS"

--- a/tests/integration/integration-tests.sh
+++ b/tests/integration/integration-tests.sh
@@ -55,10 +55,14 @@ validate_metrics() {
 
 validate_logs() {
   log=$1
-  if [ $(grep -Ri "Configuring log-forwarding to Loki." $log | wc -l) -lt 2 ]; then
+  if [ $(grep -Ri "Log-forwarding to Loki is enabled." $log | wc -l) -lt 3 ]; then
+    echo "ERROR: Could not validate logs."
+    echo "DEBUG: Log file:\n$(cat $log)"
     exit 1
   fi
-  if [ $(grep -Ri 'Layer \\\\"logging\\\\" added successfully from \\\\"/tmp/rendered_log_layer.yaml\\\\"' $log | wc -l) -lt 2 ]; then
+  if [ $(grep -Ri 'Layer \\\\"logging\\\\" added successfully from \\\\"/tmp/rendered_log_layer.yaml\\\\"' $log | wc -l) -lt 3 ]; then
+    echo "ERROR: Could not validate logs."
+    echo "DEBUG: Log file:\n$(cat $log)"
     exit 1
   fi
 }
@@ -439,7 +443,7 @@ run_example_job_in_pod_with_log_forwarding() {
 
   PREVIOUS_JOB=$(kubectl -n $NAMESPACE get pods --sort-by=.metadata.creationTimestamp | grep driver | tail -n 1 | cut -d' ' -f1)
   # start simple http server
-  LOG_FILE="/tmp/server.log"
+  LOG_FILE="/tmp/server-loki.log"
   SERVER_PORT=9091
   python3 tests/integration/resources/test_web_server.py $SERVER_PORT > $LOG_FILE &
   HTTP_SERVER_PID=$!
@@ -453,7 +457,8 @@ run_example_job_in_pod_with_log_forwarding() {
                   --conf spark.kubernetes.driver.request.cores=100m \
                   --conf spark.kubernetes.executor.request.cores=100m \
                   --conf spark.kubernetes.container.image=$IM \
-                  --conf spark.executorEnv.LOKI_URL="$IP:$PORT" \
+                  --conf spark.executorEnv.LOKI_URL="http://$IP:$PORT" \
+                  --conf spark.kubernetes.driverEnv.LOKI_URL="http://$IP:$PORT" \
                   --class org.apache.spark.examples.SparkPi \
                   local:///opt/spark/examples/jars/$JJ 1000'
 


### PR DESCRIPTION
Add log forwarding layer yaml file, which is used in sparkd.sh and it
use environment variables to configure it.
The env used are:
 - LOKI_URL - url, which can be either Loki itself or Grafana-agent
 - FLAVOUR - executor | driver to distinguish between the executor and the driver
 - SPARK_APPLICATION_ID - spark application id
 - SPARK_USER - user running these Pods / Jobs
 - HOSTNAME - Pod name / hostname

Add integration tests.

How I tested it:
```bash
$ rockcraft pack
charmed-spark_3.4.2_amd64.rock 
$ rockcraft.skopeo --insecure-policy copy oci-archive:charmed-spark_3.4.2_amd64.rock docker-daemon:my-charmed-spark:3.4.2 --dest-tls-verify=false
Getting image source signatures
Copying blob 6414378b6477 done   | 
Copying blob b2aef2bd7872 done   | 
Copying blob b73c860d028d done   | 
Copying blob 786708121d29 done   | 
Copying blob 96a2d5fe6170 done   | 
Copying config 4ea9dc90c4 done   | 
Writing manifest to image destination 
$ docker images
REPOSITORY         TAG       IMAGE ID       CREATED       SIZE
<none>             <none>    d932ff815a6c   4 hours ago   1.21GB
<none>             <none>    cc4074381dc8   4 weeks ago   1.21GB
my-charmed-spark   3.4.2     4ea9dc90c4d4   4 weeks ago   1.21GB
$ docker build -t my-charmed-spark:3.4.2 --build-arg BASE_IMAGE="my-charmed-spark:3.4.2" .
[+] Building 0.1s (5/5) FINISHED                                                    docker:default
 => [internal] load build definition from Dockerfile                                          0.0s
 => => transferring dockerfile: 209B                                                          0.0s
 => [internal] load .dockerignore                                                             0.0s
 => => transferring context: 2B                                                               0.0s
 => [internal] load metadata for docker.io/library/my-charmed-spark:3.4.2                     0.0s
 => [1/1] FROM docker.io/library/my-charmed-spark:3.4.2                                       0.0s
 => exporting to image                                                                        0.0s
 => => exporting layers                                                                       0.0s
 => => writing image sha256:43967a182b5d1db6c347972fece1d8db876b1b2d79344ed1ee680875b433d616  0.0s
 => => naming to docker.io/library/my-charmed-spark:3.4.2                                     0.0s
$ docker save my-charmed-spark:3.4.2 -o my-charmed-spark.img
$ microk8s ctr images import --base-name ghcr.io/canonical/my-charmed-spark my-charmed-spark.img
unpacking docker.io/library/my-charmed-spark:3.4.2 (sha256:0cbcb7a400d59e48928983ddf659b576f61a3903c9d900e4752d43b12ae3c2f6)...done

$ cat spark-defaults.conf 
spark.kubernetes.container.image=docker.io/library/my-charmed-spark:3.4.2 
# using grafana-agent-k8s deployed only for this purpose
$ spark-client.pyspark --username spark --namespace spark --properties-file ./spark-defaults.conf -v --conf spark.executorEnv.LOKI_URL=http://grafana-agent-k8s-0.grafana-agent-k8s-endpoints.spark-o11y.svc.cluster.local:3500/loki/api/v1/push
# followed example from https://canonical.com/data/docs/spark/k8s/t-spark-shell to see some logs
...
>>> spark.sparkContext.parallelize(lines.splitlines(), 2).map(count_vowels).reduce(add)

$ k -n spark get pods
NAME                                   READY   STATUS    RESTARTS   AGE
pysparkshell-fb00bc9289e61c8a-exec-1   1/1     Running   0          2s
pysparkshell-fb00bc9289e61c8a-exec-2   1/1     Running   0          2s
$ k -n spark logs pysparkshell-fb00bc9289e61c8a-exec-1 | grep -A 15 "Configuring log-forwarding to Loki."
2024-10-14T07:20:14.451Z [sparkd] Configuring log-forwarding to Loki.
2024-10-14T07:20:14.454Z [sparkd] log-targets:
2024-10-14T07:20:14.454Z [sparkd]   grafana-agent-k8s:
2024-10-14T07:20:14.454Z [sparkd]     override: replace
2024-10-14T07:20:14.454Z [sparkd]     type: loki
2024-10-14T07:20:14.454Z [sparkd]     location: http://grafana-agent-k8s-0.grafana-agent-k8s-endpoints.spark-o11y.svc.cluster.local:3500/loki/api/v1/push
2024-10-14T07:20:14.454Z [sparkd]     services: [all]
2024-10-14T07:20:14.454Z [sparkd]     labels:
2024-10-14T07:20:14.454Z [sparkd]       product: charmed-spark
2024-10-14T07:20:14.454Z [sparkd]       app: spark
2024-10-14T07:20:14.454Z [sparkd]       app_id: spark-201e7bde966b447b99445ae77dd098bd
2024-10-14T07:20:14.454Z [sparkd]       user: rgildein
2024-10-14T07:20:14.454Z [sparkd]       pod: pysparkshell-fb00bc9289e61c8a-exec-1
2024-10-14T07:20:14.457Z [pebble] POST /v1/layers 280.628µs 200
2024-10-14T07:20:14.457Z [sparkd] Layer "logging" added successfully from "/tmp/rendered_log_layer.yaml"
```
![Screenshot from 2024-10-15 13-14-06](https://github.com/user-attachments/assets/3161fe28-77bc-4c50-a3e2-73a00d659f11)

```bash
spark-client.spark-submit \
                  --username spark --namespace spark \
                  --conf spark.kubernetes.driver.request.cores=100m \
                  --conf spark.kubernetes.executor.request.cores=100m \
                  --conf spark.kubernetes.container.image=docker.io/library/my-charmed-spark:3.4.2 \
                  --conf spark.executorEnv.LOKI_URL='http://grafana-agent-k8s-0.grafana-agent-k8s-endpoints.spark-o11y.svc.cluster.local:3500/loki/api/v1/push' \
                  --conf spark.kubernetes.driverEnv.LOKI_URL='http://grafana-agent-k8s-0.grafana-agent-k8s-endpoints.spark-o11y.svc.cluster.local:3500/loki/api/v1/push' \
                  --class org.apache.spark.examples.SparkPi \
                  local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 1000
```
![Screenshot from 2024-10-15 12-40-32](https://github.com/user-attachments/assets/fba37516-fe76-43e5-87d5-45d0c9e11010)


