### PR TITLE
[MISC] Add missing jars to 3.5-GPU Rock

### DIFF
--- a/images/charmed-spark-gpu/rockcraft.yaml
+++ b/images/charmed-spark-gpu/rockcraft.yaml
@@ -100,24 +100,27 @@ parts:
       cd $CRAFT_PART_INSTALL/opt/spark/jars
 
       ICEBERG_SPARK_RUNTIME_VERSION='3.5_2.12'
-      ICEBERG_VERSION='1.7.1'
-      SPARK_METRICS_VERSION='3.4-1.0.1'
+      ICEBERG_VERSION='1.9.1'
+      SPARK_METRICS_VERSION='3.4-1.0.5'
       SERVLET_FILTERS_VERSION='0.0.1'
+      PROMETHEUS_JMX_EXPORTER_VERSION='0.20.0'
       NVIDIA_RAPIDS_VERSION='25.06.0'
       POSTGRESQL_VERSION='42.7.2'
-      SHA1SUM_ICEBERG_JAR='03c97e0cf547c21ef1fe5c735a2bc306340ec785'
-      SHA512SUM_SPARK_METRICS_ASSEMBLY_JAR='493cf77133cbf03e96fb848121ce10ac16e6f907f595df637649b98b42118e57d6b6e1bdab71bfee3394eb369637c5b4f6b05dd8fa30a1ff6899e74069c972ce'
+      SHA1SUM_ICEBERG_JAR='577f2d40043ab6af4387eef5e856bdde06a931e6'
+      SHA512SUM_SPARK_METRICS_ASSEMBLY_JAR='5603f59fe6362bfc0e66c7da17b749b1d859fe29425aa067c6efe4393f9af59ac11d22c759ce5265938ebaabe97d5c42af21e2a8fed8aaeb52eaaf5b222a83c9'
       SHA512SUM_SPARK_SERVLET_FILTER_JAR='ffeb809d58ef0151d513b09d4c2bfd5cc064b0b888ca45899687aed2f42bcb1ce9834be9709290dd70bd9df84049f02cbbff6c2d5ec3c136c278c93f167c8096'
+      SHA1SUM_PROMETHEUS_JMX_EXPORTER='7b8a98e3482cee8889698ef391b85c47a3c4ce5b'
       SHA1SUM_NVIDIA_RAPIDS='64d2e313ffc9c8ac97256d593783cd738ca01b11'
       SHA1SUM_POSTGRESQL='86ed42574cd68662b05d3b00432a34e9a34cb12c'
 
-      # "https://github.com/canonical/central-uploader/releases/download/spark-metrics-assembly-LIB_VERSION/spark-metrics-assembly-LIB_VERSION.jar $SPARK_METRICS_VERSION sha512sum $SHA512SUM_SPARK_METRICS_ASSEMBLY_JAR"
-
       JARS=(
       "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-${ICEBERG_SPARK_RUNTIME_VERSION}/LIB_VERSION/iceberg-spark-runtime-${ICEBERG_SPARK_RUNTIME_VERSION}-LIB_VERSION.jar $ICEBERG_VERSION sha1sum $SHA1SUM_ICEBERG_JAR"
+      "https://github.com/canonical/central-uploader/releases/download/spark-metrics-assembly-LIB_VERSION/spark-metrics-assembly-LIB_VERSION.jar $SPARK_METRICS_VERSION sha512sum $SHA512SUM_SPARK_METRICS_ASSEMBLY_JAR"
       "https://github.com/canonical/central-uploader/releases/download/servlet-filters-LIB_VERSION/servlet-filters-LIB_VERSION.jar $SERVLET_FILTERS_VERSION sha512sum $SHA512SUM_SPARK_SERVLET_FILTER_JAR"
+      "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/LIB_VERSION/jmx_prometheus_javaagent-LIB_VERSION.jar $PROMETHEUS_JMX_EXPORTER_VERSION sha1sum $SHA1SUM_PROMETHEUS_JMX_EXPORTER"
       "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/LIB_VERSION/rapids-4-spark_2.12-LIB_VERSION.jar $NVIDIA_RAPIDS_VERSION sha1sum $SHA1SUM_NVIDIA_RAPIDS"
       "https://repo1.maven.org/maven2/org/postgresql/postgresql/LIB_VERSION/postgresql-LIB_VERSION.jar $POSTGRESQL_VERSION sha1sum $SHA1SUM_POSTGRESQL"
+
       )
       for ENTRY in "${JARS[@]}"; do
         echo "$ENTRY"

--- a/images/charmed-spark-gpu/rockcraft.yaml
+++ b/images/charmed-spark-gpu/rockcraft.yaml
@@ -104,10 +104,12 @@ parts:
       SPARK_METRICS_VERSION='3.4-1.0.1'
       SERVLET_FILTERS_VERSION='0.0.1'
       NVIDIA_RAPIDS_VERSION='25.06.0'
+      POSTGRESQL_VERSION='42.7.2'
       SHA1SUM_ICEBERG_JAR='03c97e0cf547c21ef1fe5c735a2bc306340ec785'
       SHA512SUM_SPARK_METRICS_ASSEMBLY_JAR='493cf77133cbf03e96fb848121ce10ac16e6f907f595df637649b98b42118e57d6b6e1bdab71bfee3394eb369637c5b4f6b05dd8fa30a1ff6899e74069c972ce'
       SHA512SUM_SPARK_SERVLET_FILTER_JAR='ffeb809d58ef0151d513b09d4c2bfd5cc064b0b888ca45899687aed2f42bcb1ce9834be9709290dd70bd9df84049f02cbbff6c2d5ec3c136c278c93f167c8096'
       SHA1SUM_NVIDIA_RAPIDS='64d2e313ffc9c8ac97256d593783cd738ca01b11'
+      SHA1SUM_POSTGRESQL='86ed42574cd68662b05d3b00432a34e9a34cb12c'
 
       # "https://github.com/canonical/central-uploader/releases/download/spark-metrics-assembly-LIB_VERSION/spark-metrics-assembly-LIB_VERSION.jar $SPARK_METRICS_VERSION sha512sum $SHA512SUM_SPARK_METRICS_ASSEMBLY_JAR"
 
@@ -115,6 +117,7 @@ parts:
       "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-${ICEBERG_SPARK_RUNTIME_VERSION}/LIB_VERSION/iceberg-spark-runtime-${ICEBERG_SPARK_RUNTIME_VERSION}-LIB_VERSION.jar $ICEBERG_VERSION sha1sum $SHA1SUM_ICEBERG_JAR"
       "https://github.com/canonical/central-uploader/releases/download/servlet-filters-LIB_VERSION/servlet-filters-LIB_VERSION.jar $SERVLET_FILTERS_VERSION sha512sum $SHA512SUM_SPARK_SERVLET_FILTER_JAR"
       "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/LIB_VERSION/rapids-4-spark_2.12-LIB_VERSION.jar $NVIDIA_RAPIDS_VERSION sha1sum $SHA1SUM_NVIDIA_RAPIDS"
+      "https://repo1.maven.org/maven2/org/postgresql/postgresql/LIB_VERSION/postgresql-LIB_VERSION.jar $POSTGRESQL_VERSION sha1sum $SHA1SUM_POSTGRESQL"
       )
       for ENTRY in "${JARS[@]}"; do
         echo "$ENTRY"


### PR DESCRIPTION
## Changes

- Add missing jars to the GPU rock: jmx exporter, postgresql
- Align the versions of iceberg and spark metric with the non-GPU rock