### PR TITLE
[DPE-7941] Add gpu executor pod template to Kyuubi image

### DIFF
--- a/images/charmed-spark-kyuubi/Dockerfile
+++ b/images/charmed-spark-kyuubi/Dockerfile
@@ -68,6 +68,8 @@
     # Copy local files to the container
     COPY ./bin/kyuubi.sh /opt/pebble/kyuubi.sh
     RUN chown _daemon_:_daemon_ /opt/pebble/kyuubi.sh
+    COPY ./conf/gpu_executor_template.yaml /etc/spark8t/conf/gpu_executor_template.yaml
+    RUN chown _daemon_:_daemon_ /etc/spark8t/conf/gpu_executor_template.yaml
 
     # Copy hive schematool to the image
     COPY ./bin/schematool.sh /opt/hive/bin/schematool.sh

--- a/images/charmed-spark-kyuubi/conf/gpu_executor_template.yaml
+++ b/images/charmed-spark-kyuubi/conf/gpu_executor_template.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: executor
+      resources:
+        limits:
+          nvidia.com/gpu: 1


### PR DESCRIPTION
Following up on DA211, the minimal gpu pod template is now part of the charmed-spark-kyuubi OCI resource, so that it can schedule jobs without having the charm write it to its workload first.