### PR TITLE
[DPE-8334] Bump microk8s default version to LTS 1.32

### DIFF
--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           sudo -E bash ./tests/integration/setup-environment.sh
         env:
-          MICROK8S_CHANNEL: 1.28/stable
+          MICROK8S_CHANNEL: 1.32/stable
 
       - name: Setup microk8s
         timeout-minutes: 30

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,10 @@ jobs:
     strategy:
       matrix:
         env: [integration]
-        k8s_version: ["1.28-strict/stable","1.29-strict/stable", "1.30-strict/stable" ]
+        k8s_version:
+          - 1.28-strict/stable
+          - 1.32-strict/stable
+          - 1.34-strict/stable
       fail-fast: false
     env:
       AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
@@ -57,7 +60,7 @@ jobs:
           # Import artifact into microk8s to be used in integration tests
           sudo make microk8s-import PREFIX=test- REPOSITORY=ghcr.io/canonical/ \
             -o ${{ steps.artifact.outputs.base_artifact_name }}
-          
+
           sg snap_microk8s -c "make tests"
 
       - name: Run tests (Jupyter)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PLATFORM := amd64
 FLAVOUR := "spark"
 
 # The channel of `microk8s` snap to be used for testing
-MICROK8S_CHANNEL := "1.28-strict/stable"
+MICROK8S_CHANNEL := "1.32-strict/stable"
 
 # The Azure credentials supplied as environment variables
 AZURE_STORAGE_ACCOUNT := ${AZURE_STORAGE_ACCOUNT}


### PR DESCRIPTION
This PR changes the default microk8s version we use to the LTS 1.32. In addition, we switch 1.29 to 1.34, so that our artifacts are more future-proof.