### PR TITLE
[MISC] Fix the incorrect artifact name for SBOM in trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           scan-type: "image"
           format: "spdx-json"
-          output: "dependency-results.sbom.json"
+          output: "dependency-results-${{ matrix.flavour }}.sbom.json"
           image-ref: "trivy/${{ matrix.flavour }}:test"
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           severity: "MEDIUM,HIGH,CRITICAL"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -78,7 +78,7 @@ jobs:
           severity: "MEDIUM,HIGH,CRITICAL"
           scanners: "vuln"
 
-      - name: Upload trivy report as a Github artifact
+      - name: Upload trivy report as a Github artifact (${{ matrix.flavour }})
         uses: actions/upload-artifact@v4
         with:
           name: trivy-sbom-report-${{ matrix.flavour }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -81,6 +81,6 @@ jobs:
       - name: Upload trivy report as a Github artifact
         uses: actions/upload-artifact@v4
         with:
-          name: trivy-sbom-report
+          name: trivy-sbom-report-${{ matrix.flavour }}
           path: "${{ github.workspace }}/dependency-results-${{ matrix.flavour }}.sbom.json"
           retention-days: 90


### PR DESCRIPTION
There was some mismatch in the name of artifact that was generated vs the artifact that was uploaded.

This resulted in the SBOM artifact not uploaded to GitHub artifacts during the trivy runs.
<img width="1440" height="421" alt="image" src="https://github.com/user-attachments/assets/36b6e672-27f0-4275-8ca8-771764cff67c" />
