### PR TITLE
[PRA-134] Add py4j dependency to PYTHONPATH in rock image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,31 @@ jobs:
     needs:
       - lint
     steps:
+      - name: Disk cleanup
+        shell: bash
+        run: |
+          sudo rm -rf \
+            /opt/google \
+            /opt/hostedtoolcache \
+            /opt/microsoft/powershell \
+            /opt/microsoft/msedge \
+            "$AGENT_TOOLSDIRECTORY" \
+            /usr/lib/firefox \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/gradle* \
+            /usr/share/miniconda \
+            /usr/share/sbt \
+            /usr/share/swift \
+            /home/linuxbrew
+          pipx uninstall-all
+          printf '\nDisk usage\n'
+          df --human-readable
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -42,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-          sudo snap install rockcraft --classic --edge    
+          sudo snap install rockcraft --classic --edge
 
       - name: Build image
         run: sudo make build
@@ -65,7 +90,7 @@ jobs:
 
       - name: Change artifact permissions
         run: sudo chmod a+r  ${{ steps.artifact.outputs.base_artifact_name }} ${{ steps.artifact.outputs.jupyter_artifact_name }} ${{ steps.artifact.outputs.kyuubi_artifact_name }}
-          
+
       - name: Upload locally built artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_gpu.yaml
+++ b/.github/workflows/build_gpu.yaml
@@ -23,6 +23,31 @@ jobs:
     needs:
       - lint
     steps:
+      - name: Disk cleanup
+        shell: bash
+        run: |
+          sudo rm -rf \
+            /opt/google \
+            /opt/hostedtoolcache \
+            /opt/microsoft/powershell \
+            /opt/microsoft/msedge \
+            "$AGENT_TOOLSDIRECTORY" \
+            /usr/lib/firefox \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/gradle* \
+            /usr/share/miniconda \
+            /usr/share/sbt \
+            /usr/share/swift \
+            /home/linuxbrew
+          pipx uninstall-all
+          printf '\nDisk usage\n'
+          df --human-readable
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -34,8 +59,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-          sudo snap install rockcraft --classic --edge    
-      
+          sudo snap install rockcraft --classic --edge
+
       - name: Build image (GPU)
         run: sudo make build FLAVOUR=gpu
 
@@ -47,7 +72,7 @@ jobs:
 
       - name: Change artifact permissions
         run: sudo chmod a+r  ${{ steps.artifact.outputs.gpu_artifact_name }}
-          
+
       - name: Upload locally built artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -88,6 +88,9 @@ jobs:
           sudo make microk8s-import FLAVOUR=gpu PREFIX=test- REPOSITORY=ghcr.io/canonical/ \
             -o ${{ steps.artifact.outputs.gpu_artifact_name }}
 
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
+
       - name: Run integration tests on GPU
         run: |
           echo "Start test..."

--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -88,9 +88,6 @@ jobs:
           sudo make microk8s-import FLAVOUR=gpu PREFIX=test- REPOSITORY=ghcr.io/canonical/ \
             -o ${{ steps.artifact.outputs.gpu_artifact_name }}
 
-      - name: Setup upterm session
-        uses: owenthereal/action-upterm@v1
-
       - name: Run integration tests on GPU
         run: |
           echo "Start test..."

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -52,8 +52,8 @@ jobs:
           name: charmed-spark
           path: charmed-spark
 
-      # - name: Setup upterm session
-      #   uses: owenthereal/action-upterm@v1
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
 
 
       - name: Run tests

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -52,6 +52,10 @@ jobs:
           name: charmed-spark
           path: charmed-spark
 
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
+
+
       - name: Run tests
         run: |
           # Unpack Artifact

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -52,10 +52,6 @@ jobs:
           name: charmed-spark
           path: charmed-spark
 
-      - name: Setup upterm session
-        uses: owenthereal/action-upterm@v1
-
-
       - name: Run tests
         run: |
           # Unpack Artifact

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -52,8 +52,8 @@ jobs:
           name: charmed-spark
           path: charmed-spark
 
-      - name: Setup upterm session
-        uses: owenthereal/action-upterm@v1
+      # - name: Setup upterm session
+      #   uses: owenthereal/action-upterm@v1
 
 
       - name: Run tests
@@ -64,7 +64,7 @@ jobs:
           # Import artifact into microk8s to be used in integration tests
           sudo make microk8s-import PREFIX=test- REPOSITORY=ghcr.io/canonical/ \
             -o ${{ steps.artifact.outputs.base_artifact_name }}
-          
+
           sg microk8s -c "make tests"
 
       - name: Run tests (Jupyter)

--- a/images/charmed-spark-gpu/rockcraft.yaml
+++ b/images/charmed-spark-gpu/rockcraft.yaml
@@ -231,6 +231,12 @@ parts:
       chown -R ${SPARK_GID}:${SPARK_UID} var/log/spark
       chmod -R 750 var/log/spark
 
+      # Create a symlink to py4j
+      (
+        cd opt/spark/python/lib
+        ln -s py4j-*-src.zip py4j.zip
+      )
+
       # This is needed to run the spark job, as it requires RW+ access on the spark folder
       chown -R ${SPARK_GID}:${SPARK_UID} opt/spark
       chmod -R 750 opt/spark

--- a/images/charmed-spark-gpu/rockcraft.yaml
+++ b/images/charmed-spark-gpu/rockcraft.yaml
@@ -25,7 +25,7 @@ environment:
   SPARK_HOME: /opt/spark
   SPARK_CONFS: /etc/spark8t/conf
   JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-  PYTHONPATH: /opt/spark/python:/opt/spark8t/python/dist:/usr/lib/python3.10/site-packages
+  PYTHONPATH: /opt/spark/python:/opt/spark8t/python/dist:/opt/spark/python/lib/py4j.zip:/usr/lib/python3.10/site-packages
   PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark:/opt/spark/bin:/opt/spark/python/bin:/opt/spark-client/python/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/lib/jvm/java-17-openjdk-amd64/bin
   HOME: /var/lib/spark
   SPARK_USER_DATA: /var/lib/spark

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -230,7 +230,7 @@ parts:
       chmod -R 750 var/log/spark
 
       # Create a symlink to py4j
-      ln -s opt/spark/python/lib/py4j-*-src.zip opt/spark/python/lib/py4j.zip
+      ln -s /opt/spark/python/lib/py4j-*-src.zip opt/spark/python/lib/py4j.zip
 
       # This is needed to run the spark job, as it requires RW+ access on the spark folder
       chown -R ${SPARK_GID}:${SPARK_UID} opt/spark

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -241,4 +241,4 @@ parts:
       chmod a+x opt/decom.sh
 
       # Create a symlink to py4j
-      ln -s /opt/spark/python/lib/py4j-*-src.zip /opt/spark/python/lib/py4j.zip
+      ln -s opt/spark/python/lib/py4j-*-src.zip opt/spark/python/lib/py4j.zip

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -230,7 +230,10 @@ parts:
       chmod -R 750 var/log/spark
 
       # Create a symlink to py4j
-      ln -s /opt/spark/python/lib/py4j-*-src.zip opt/spark/python/lib/py4j.zip
+      (
+        cd opt/spark/python/lib
+        ln -s py4j-*-src.zip py4j.zip
+      )
 
       # This is needed to run the spark job, as it requires RW+ access on the spark folder
       chown -R ${SPARK_GID}:${SPARK_UID} opt/spark

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -229,6 +229,9 @@ parts:
       chown -R ${SPARK_GID}:${SPARK_UID} var/log/spark
       chmod -R 750 var/log/spark
 
+      # Create a symlink to py4j
+      ln -s opt/spark/python/lib/py4j-*-src.zip opt/spark/python/lib/py4j.zip
+
       # This is needed to run the spark job, as it requires RW+ access on the spark folder
       chown -R ${SPARK_GID}:${SPARK_UID} opt/spark
       chmod -R 750 opt/spark
@@ -240,5 +243,3 @@ parts:
       mv opt/spark/decom.sh opt/decom.sh
       chmod a+x opt/decom.sh
 
-      # Create a symlink to py4j
-      ln -s opt/spark/python/lib/py4j-*-src.zip opt/spark/python/lib/py4j.zip

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -25,7 +25,7 @@ environment:
   SPARK_CONFS: /etc/spark8t/conf
   SPARK_CONF_DIR: /etc/spark8t/conf
   JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-  PYTHONPATH: /opt/spark/python:/opt/spark8t/python/dist:/usr/lib/python3.10/site-packages:/opt/spark/python/lib/py4j.zip
+  PYTHONPATH: /opt/spark/python:/opt/spark8t/python/dist:/opt/spark/python/lib/py4j.zip:/usr/lib/python3.10/site-packages
   PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark:/opt/spark/bin:/opt/spark/python/bin:/opt/spark-client/python/bin
   HOME: /var/lib/spark
   SPARK_USER_DATA: /var/lib/spark

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -25,7 +25,7 @@ environment:
   SPARK_CONFS: /etc/spark8t/conf
   SPARK_CONF_DIR: /etc/spark8t/conf
   JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-  PYTHONPATH: /opt/spark/python:/opt/spark8t/python/dist:/usr/lib/python3.10/site-packages
+  PYTHONPATH: /opt/spark/python:/opt/spark8t/python/dist:/usr/lib/python3.10/site-packages:/opt/spark/python/lib/py4j.zip
   PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark:/opt/spark/bin:/opt/spark/python/bin:/opt/spark-client/python/bin
   HOME: /var/lib/spark
   SPARK_USER_DATA: /var/lib/spark
@@ -240,3 +240,5 @@ parts:
       mv opt/spark/decom.sh opt/decom.sh
       chmod a+x opt/decom.sh
 
+      # Create a symlink to py4j 
+      ln -s py4j-*-src.zip py4j.zip

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -241,4 +241,4 @@ parts:
       chmod a+x opt/decom.sh
 
       # Create a symlink to py4j
-      ln -s py4j-*-src.zip py4j.zip
+      ln -s /opt/spark/python/lib/py4j-*-src.zip /opt/spark/python/lib/py4j.zip

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -240,5 +240,5 @@ parts:
       mv opt/spark/decom.sh opt/decom.sh
       chmod a+x opt/decom.sh
 
-      # Create a symlink to py4j 
+      # Create a symlink to py4j
       ln -s py4j-*-src.zip py4j.zip

--- a/tests/integration/integration-tests-gpu.sh
+++ b/tests/integration/integration-tests-gpu.sh
@@ -315,6 +315,31 @@ test_sql_gpu_example_in_pod() {
   run_test_sql_gpu_example_in_pod $NAMESPACE spark
 }
 
+
+
+import_pyspark_from_python_runtime_in_pod() {
+  echo "import_pyspark_from_python_runtime_in_pod ${1} ${2}"
+
+  NAMESPACE=$1
+  USERNAME=$2
+
+  out=$(kubectl -n "$NAMESPACE" exec testpod -- python3 -c 'import py4j; import pyspark;' 2> >(tee /tmp/err.log))
+  rc=$?
+
+  if [[ $rc -ne 0 || -s /tmp/err.log ]]; then
+      echo "Canont import pyspark from inside pod:"
+      echo "  Exit code: $rc"
+      echo "  Stderr:"
+      cat /tmp/err.log
+      exit 1
+  fi
+}
+
+test_import_pyspark_in_pod() {
+  import_pyspark_from_python_runtime_in_pod $NAMESPACE spark
+}
+
+
 cleanup_user_failure_in_pod() {
   teardown_test_pod
   cleanup_user_failure
@@ -327,6 +352,12 @@ echo -e "##################################"
 
 kubectl create namespace $NAMESPACE
 setup_admin_pod $ADMIN_POD_NAME $(spark_image) $NAMESPACE
+
+echo -e "##################################"
+echo -e "IMPORT pyspark FROM INSIDE POD"
+echo -e "##################################"
+
+(setup_user_context && test_import_pyspark_in_pod && cleanup_user_success) || cleanup_user_failure_in_pod
 
 echo -e "##################################"
 echo -e "RUN EXAMPLE THAT USES GPU"

--- a/tests/integration/integration-tests.sh
+++ b/tests/integration/integration-tests.sh
@@ -550,6 +550,7 @@ run_spark_shell_in_pod() {
 
   # Check job output
   # Sample output
+
   # "Pi is roughly 3.13956232343"
 
   echo -e "$(kubectl -n $NAMESPACE exec testpod -- env UU="$USERNAME" NN="$NAMESPACE" CMDS="$SPARK_SHELL_COMMANDS" IM="$(spark_image)" /bin/bash -c 'echo "$CMDS" | spark-client.spark-shell --username $UU --namespace $NN --conf spark.kubernetes.container.image=$IM')" > spark-shell.out
@@ -632,8 +633,8 @@ test_spark_sql_in_pod_using_abfss() {
 }
 
 
-run_pyspark_in_pod() {
-  echo "run_pyspark_in_pod ${1} ${2}"
+run_pyspark_shell_in_pod() {
+  echo "run_pyspark_shell_in_pod ${1} ${2}"
 
   NAMESPACE=$1
   USERNAME=$2
@@ -653,14 +654,38 @@ run_pyspark_in_pod() {
   validate_pi_value $pi
 }
 
-test_pyspark_in_pod() {
-  run_pyspark_in_pod $NAMESPACE spark
+test_pyspark_shell_in_pod() {
+  run_pyspark_shell_in_pod $NAMESPACE spark
 }
 
 cleanup_user_failure_in_pod() {
   teardown_test_pod
   cleanup_user_failure
 }
+
+
+import_pyspark_from_python_runtime_in_pod() {
+  echo "import_pyspark_from_python_runtime_in_pod ${1} ${2}"
+
+  NAMESPACE=$1
+  USERNAME=$2
+
+  out=$(kubectl -n "$NAMESPACE" exec testpod -- python3 -c 'import py4j; import pyspark;' 2> >(tee /tmp/err.log))
+  rc=$?
+
+  if [[ $rc -ne 0 || -s /tmp/err.log ]]; then
+      echo "Canont import pyspark from inside pod:"
+      echo "  Exit code: $rc"
+      echo "  Stderr:"
+      cat /tmp/err.log
+      exit 1
+  fi
+}
+
+test_import_pyspark_in_pod() {
+  import_pyspark_from_python_runtime_in_pod $NAMESPACE spark
+}
+
 
 
 echo -e "##################################"
@@ -685,7 +710,13 @@ echo -e "##################################"
 echo -e "RUN PYSPARK IN POD"
 echo -e "##################################"
 
-(setup_user_context && test_pyspark_in_pod && cleanup_user_success) || cleanup_user_failure_in_pod
+(setup_user_context && test_pyspark_shell_in_pod && cleanup_user_success) || cleanup_user_failure_in_pod
+
+echo -e "##################################"
+echo -e "IMPORT pyspark FROM INSIDE POD"
+echo -e "##################################"
+
+(setup_user_context && test_import_pyspark_in_pod && cleanup_user_success) || cleanup_user_failure_in_pod
 
 echo -e "##################################"
 echo -e "RUN SPARK SQL IN POD (Using S3 Object Storage)"

--- a/tests/integration/integration-tests.sh
+++ b/tests/integration/integration-tests.sh
@@ -658,11 +658,6 @@ test_pyspark_shell_in_pod() {
   run_pyspark_shell_in_pod $NAMESPACE spark
 }
 
-cleanup_user_failure_in_pod() {
-  teardown_test_pod
-  cleanup_user_failure
-}
-
 
 import_pyspark_from_python_runtime_in_pod() {
   echo "import_pyspark_from_python_runtime_in_pod ${1} ${2}"
@@ -686,6 +681,11 @@ test_import_pyspark_in_pod() {
   import_pyspark_from_python_runtime_in_pod $NAMESPACE spark
 }
 
+
+cleanup_user_failure_in_pod() {
+  teardown_test_pod
+  cleanup_user_failure
+}
 
 
 echo -e "##################################"


### PR DESCRIPTION
Fixes #179 

In this PR, we add a soft link pointing to the py4j dependency to a static path, and add that path to the PYTHONPATH. This will ensure that the py4j zip will be in path even if the version of Py4j changes, without changing the code again.