### PR TITLE
[MISC] Perform disk cleanup at the start of all workflows

### DIFF
--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -59,7 +59,6 @@ jobs:
             /usr/share/sbt \
             /usr/share/swift \
             /home/linuxbrew
-          pipx uninstall-all
           printf '\nDisk usage\n'
           df --human-readable
 

--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -38,6 +38,31 @@ jobs:
     needs: [start-runner]
     runs-on: ${{ needs.start-runner.outputs.label }}
     steps:
+      - name: Disk cleanup
+        shell: bash
+        run: |
+          sudo rm -rf \
+            /opt/google \
+            /opt/hostedtoolcache \
+            /opt/microsoft/powershell \
+            /opt/microsoft/msedge \
+            "$AGENT_TOOLSDIRECTORY" \
+            /usr/lib/firefox \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/gradle* \
+            /usr/share/miniconda \
+            /usr/share/sbt \
+            /usr/share/swift \
+            /home/linuxbrew
+          pipx uninstall-all
+          printf '\nDisk usage\n'
+          df --human-readable
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,6 +27,31 @@ jobs:
       AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
       AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
     steps:
+      - name: Disk cleanup
+        shell: bash
+        run: |
+          sudo rm -rf \
+            /opt/google \
+            /opt/hostedtoolcache \
+            /opt/microsoft/powershell \
+            /opt/microsoft/msedge \
+            "$AGENT_TOOLSDIRECTORY" \
+            /usr/lib/firefox \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/gradle* \
+            /usr/share/miniconda \
+            /usr/share/sbt \
+            /usr/share/swift \
+            /home/linuxbrew
+          pipx uninstall-all
+          printf '\nDisk usage\n'
+          df --human-readable
+
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Recently a lot of our workflows are failing because of shortage of disk storage. This fix will give a little bit of relief to our failing tests.