### PR TITLE
[PRA-104] Enable release job on 4.0/edge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ on:
     branches:
       - "3.4/edge"
       - "3.5/edge"
+      - "4.0/edge"
 
 jobs:
   build-rocks:


### PR DESCRIPTION
I forgot to add `4.0/edge`  to the list of release branches