### PR TITLE
[PRA-104] Re enable default image testing (4.0) 

### DIFF
--- a/images/charmed-spark-gpu/conf/spark-defaults.conf
+++ b/images/charmed-spark-gpu/conf/spark-defaults.conf
@@ -1,1 +1,1 @@
-spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark-gpu:4.0-22.04_edge
+spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark-gpu:4.0.1-22.04_edge

--- a/images/charmed-spark/conf/spark-defaults.conf
+++ b/images/charmed-spark/conf/spark-defaults.conf
@@ -1,1 +1,1 @@
-spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:4.0-22.04_edge
+spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:4.0.1-22.04_edge

--- a/tests/integration/integration-tests-gpu.sh
+++ b/tests/integration/integration-tests-gpu.sh
@@ -368,12 +368,11 @@ echo -e "##################################"
 
 (setup_user_context && test_gpu_example_in_pod && cleanup_user_success) || cleanup_user_failure_in_pod
 
-# TODO(arm): Re-enable once we have an arm release
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE THAT USES GPU WITH DEFAULT IMAGE"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE THAT USES GPU WITH DEFAULT IMAGE"
+echo -e "##################################"
 
-# (setup_user_context && test_gpu_example_in_pod_with_default_image && cleanup_user_success) || cleanup_user_failure_in_pod
+(setup_user_context && test_gpu_example_in_pod_with_default_image && cleanup_user_success) || cleanup_user_failure_in_pod
 
 echo -e "##################################"
 echo -e "RUN SQL EXAMPLE THAT USES GPU"

--- a/tests/integration/integration-tests.sh
+++ b/tests/integration/integration-tests.sh
@@ -709,12 +709,11 @@ echo -e "##################################"
 
 (setup_user_context && test_example_job_in_pod && cleanup_user_success) || cleanup_user_failure_in_pod
 
-# TODO(arm): Re-enable once we have an arm release
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE JOB WITH DEFAULT SPARK IMAGE"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE JOB WITH DEFAULT SPARK IMAGE"
+echo -e "##################################"
 
-# (setup_user_context && test_example_job_in_pod_with_default_image && cleanup_user_success) || cleanup_user_failure_in_pod
+(setup_user_context && test_example_job_in_pod_with_default_image && cleanup_user_success) || cleanup_user_failure_in_pod
 
 echo -e "##################################"
 echo -e "RUN SPARK SHELL IN POD"


### PR DESCRIPTION
Similar to #198

>This PR re-enables the integration tests pulling the default image.
    They were deactivated during the work on ARM, as we needed to have an ARM release available before we could run them.

