### PR TITLE
[BACKPORT] Bump spark8t to 1.2.0

### DIFF
--- a/images/charmed-spark-gpu/rockcraft.yaml
+++ b/images/charmed-spark-gpu/rockcraft.yaml
@@ -153,7 +153,7 @@ parts:
       - python3-pip
     overlay-script: |
       mkdir -p $CRAFT_PART_INSTALL/opt/spark8t/python/dist
-      pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist spark8t==1.0.0
+      pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist spark8t==1.2.0
       rm usr/bin/pip*
     stage:
       - opt/spark8t/python/dist

--- a/images/charmed-spark/rockcraft.yaml
+++ b/images/charmed-spark/rockcraft.yaml
@@ -149,7 +149,7 @@ parts:
       - python3-pip
     overlay-script: |
       mkdir -p $CRAFT_PART_INSTALL/opt/spark8t/python/dist
-      pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist spark8t==1.0.0
+      pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist spark8t==1.2.0
       rm usr/bin/pip*
     stage:
       - opt/spark8t/python/dist

--- a/tests/integration/integration-tests-kyuubi.sh
+++ b/tests/integration/integration-tests-kyuubi.sh
@@ -204,7 +204,12 @@ teardown_test_pods() {
 
 test_jdbc_connection(){
   # Test the JDBC endpoint exposed by Kyuubi by running a few SQL queries
-  jdbc_endpoint=$(kubectl -n $NAMESPACE exec kyuubi-test -- pebble logs kyuubi | grep 'Starting and exposing JDBC connection at:' | rev | cut -d' ' -f1 | rev)
+  echo "Waiting for a few seconds such that Kyuubi server startup is complete..."
+  sleep 10
+
+  host=$(kubectl -n $NAMESPACE exec kyuubi-test -- hostname)
+  port=10009
+  jdbc_endpoint="jdbc:hive2://$host:$port/"
   echo "Testing JDBC endpoint '$jdbc_endpoint'..."
  
   commands=$(cat ./tests/integration/resources/test-kyuubi.sql)


### PR DESCRIPTION
This PR bumps the version of spark8t to 1.2.0, to include the feature https://github.com/canonical/spark-k8s-toolkit-py/pull/123 into our images.

This PR is for the 4.0/edge branch.