### PR TITLE
[PRA-172] Re-tag image after release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
           - os: ubuntu-22.04-arm
             arch: arm64
     runs-on: ${{ matrix.system.os }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - name: Disk cleanup
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-          sudo snap install rockcraft --classic --channel latest/stable
+          sudo snap install rockcraft --classic
 
       - name: Build image
         run: sudo make build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
           - os: ubuntu-22.04-arm
             arch: arm64
     runs-on: ${{ matrix.system.os }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: Disk cleanup
         shell: bash
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-          sudo snap install rockcraft --classic --edge
+          sudo snap install rockcraft --classic --channel latest/stable
 
       - name: Build image
         run: sudo make build

--- a/.github/workflows/build_gpu.yaml
+++ b/.github/workflows/build_gpu.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.arch == 'amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: Disk cleanup
         shell: bash
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-          sudo snap install rockcraft --classic --edge
+          sudo snap install rockcraft --classic --channel latest/stable
 
       - name: Build image (GPU)
         run: sudo make build FLAVOUR=gpu

--- a/.github/workflows/build_gpu.yaml
+++ b/.github/workflows/build_gpu.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.arch == 'amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - name: Disk cleanup
         shell: bash

--- a/.github/workflows/build_gpu.yaml
+++ b/.github/workflows/build_gpu.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-          sudo snap install rockcraft --classic --channel latest/stable
+          sudo snap install rockcraft --classic
 
       - name: Build image (GPU)
         run: sudo make build FLAVOUR=gpu

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,7 +145,14 @@ jobs:
             "docker://ghcr.io/canonical/charmed-spark-kyuubi:${ORIGINAL_TAG}"\
             "docker://ghcr.io/canonical/charmed-spark-kyuubi:${FULL_KYUUBI_TAG}" --all
 
-          echo "TODO: Re-tagging charmed-spark-jupyterlab"
+          echo "Re-tagging charmed-spark-jupyterlab"
+          FULL_JUPYTER_TAG="${FULL_SPARK_VERSION}-$(yq '.flavours.jupyter.version' images/metadata.yaml)-${BASE}_edge"
+          skopeo copy --insecure-policy \
+            "docker://ghcr.io/canonical/charmed-spark-jupyterlab:${ORIGINAL_TAG}"\
+            "docker://ghcr.io/canonical/charmed-spark-jupyterlab:${MAJOR_MINOR_TAG}" --all
+          skopeo copy --insecure-policy \
+            "docker://ghcr.io/canonical/charmed-spark-jupyterlab:${ORIGINAL_TAG}"\
+            "docker://ghcr.io/canonical/charmed-spark-jupyterlab:${FULL_JUPYTER_TAG}" --all
 
           echo "Re-tagging charmed-spark-gpu"
           FULL_GPU_TAG="${FULL_SPARK_VERSION}-$(yq '.flavours.gpu.version' images/metadata.yaml)-${BASE}_edge"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,3 +121,37 @@ jobs:
           release-rock --directory=to_export/charmed-spark-gpu/ --create-tags=true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-tag OCI resources
+        id: retag
+        run: |
+          FULL_SPARK_VERSION=$(yq '.version' images/charmed-spark/rockcraft.yaml)
+          BASE=$(yq '(.base|split("@"))[1]' images/charmed-spark/rockcraft.yaml)
+          ORIGINAL_TAG="${FULL_SPARK_VERSION}-${BASE}_edge"
+          MAJOR_MINOR_VERSION=$(echo $FULL_SPARK_VERSION | sed -n "s/\(^[0-9]*\.[0-9]*\).*/\1/p")
+          MAJOR_MINOR_TAG="${MAJOR_MINOR_VERSION}-${BASE}_edge"
+
+          echo "Re-tagging charmed-spark"
+          skopeo copy --insecure-policy \
+            "docker://ghcr.io/canonical/charmed-spark:${ORIGINAL_TAG}" \
+            "docker://ghcr.io/canonical/charmed-spark:${MAJOR_MINOR_TAG}" --all
+
+          echo "Re-tagging charmed-spark-kyuubi"
+          FULL_KYUUBI_TAG="${FULL_SPARK_VERSION}-$(yq '.flavours.kyuubi.version' images/metadata.yaml)-${BASE}_edge"
+          skopeo copy --insecure-policy \
+            "docker://ghcr.io/canonical/charmed-spark-kyuubi:${ORIGINAL_TAG}"\
+            "docker://ghcr.io/canonical/charmed-spark-kyuubi:${MAJOR_MINOR_TAG}" --all
+          skopeo copy --insecure-policy \
+            "docker://ghcr.io/canonical/charmed-spark-kyuubi:${ORIGINAL_TAG}"\
+            "docker://ghcr.io/canonical/charmed-spark-kyuubi:${FULL_KYUUBI_TAG}" --all
+
+          echo "TODO: Re-tagging charmed-spark-jupyterlab"
+
+          echo "Re-tagging charmed-spark-gpu"
+          FULL_GPU_TAG="${FULL_SPARK_VERSION}-$(yq '.flavours.gpu.version' images/metadata.yaml)-${BASE}_edge"
+          skopeo copy --insecure-policy \
+            "docker://ghcr.io/canonical/charmed-spark-gpu:${ORIGINAL_TAG}"\
+            "docker://ghcr.io/canonical/charmed-spark-gpu:${MAJOR_MINOR_TAG}" --all
+          skopeo copy --insecure-policy \
+            "docker://ghcr.io/canonical/charmed-spark-gpu:${ORIGINAL_TAG}"\
+            "docker://ghcr.io/canonical/charmed-spark-gpu:${FULL_GPU_TAG}" --all


### PR DESCRIPTION
## Changes

Addresses #208.
This PR adds a new step to the release workflow. After publishing to the `3.5.5-22.04_edge` tag, we re-tag each flavour.

I confirmed locally that the tags are properly computed (such as `3.5.5-1.10.2-22.04_edge` for the kyuubi flavour) and that we can copy the full manifests using skopeo here: https://hub.docker.com/repository/docker/batalex/charmed-spark/tags (`multi-arch-test-copied` was copied from `multi-arch-test` using the same command as in this PR).
Since we have a `docker login` action in the workflow, we should also be good with regards to auth with the registry.

This PR also adjusts the build system following our recent conversation on the rockcraft channel to use.