### PR TITLE
[PRA-221] Fix trivy scanning failure

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -50,7 +50,7 @@ jobs:
             docker-archive:${{ steps.artifact.outputs.base_artifact_name }} \
             docker-daemon:trivy/${{ matrix.flavour }}-${{ matrix.arch }}:test
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: "trivy/${{ matrix.flavour }}-${{ matrix.arch }}:test"
           format: "sarif"
@@ -66,7 +66,7 @@ jobs:
           category: ${{ matrix.flavour }}-${{ matrix.arch }}
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: "image"
           format: "spdx-json"


### PR DESCRIPTION
Fixing the CI for trivy, that has started to recently fail, e.g. see

https://github.com/canonical/charmed-spark-rock/actions/runs/22953941018/job/66631327914

Bumping the action version may hopefully fix this. 