### PR TITLE
[PRA-222] Add additional labels to rocks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,15 +58,16 @@ jobs:
         run: |
           sudo snap install yq
           sudo snap install rockcraft --classic
+          sudo snap install regclient
 
       - name: Build image
-        run: sudo make build
+        run: make build
 
       - name: Build image (Jupyter)
-        run: sudo make build FLAVOUR=jupyter
+        run: make build FLAVOUR=jupyter
 
       - name: Build image (Kyuubi)
-        run: sudo make build FLAVOUR=kyuubi
+        run: make build FLAVOUR=kyuubi
 
       - name: Get Artifact Name
         id: artifact
@@ -78,8 +79,18 @@ jobs:
           KYUUBI_ARTIFACT=$(make help FLAVOUR=kyuubi | grep 'Artifact: ')
           echo "kyuubi_artifact_name=${KYUUBI_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
 
-      - name: Change artifact permissions
-        run: sudo chmod a+r  ${{ steps.artifact.outputs.base_artifact_name }} ${{ steps.artifact.outputs.jupyter_artifact_name }} ${{ steps.artifact.outputs.kyuubi_artifact_name }}
+      - name: Add additional labels
+        run: |
+          COMMIT_ID=$(git log -1 --format=%H)
+          for file in ${{ steps.artifact.outputs.base_artifact_name }} ${{ steps.artifact.outputs.jupyter_artifact_name }} ${{ steps.artifact.outputs.kyuubi_artifact_name }}; do
+              echo "Processing ${file}"
+              rockcraft.skopeo copy "oci-archive:${file}" oci:to_process:latest
+              regctl image mod ocidir://to_process:latest --replace \
+                --label "org.opencontainers.image.revision=${COMMIT_ID}" \
+                --label "org.opencontainers.image.source=${{ github.repositoryUrl }}"
+              regctl image export ocidir://to_process:latest "${file}"
+              rm -r to_process
+          done
 
       - name: Upload locally built artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,15 +82,36 @@ jobs:
       - name: Add additional labels
         run: |
           COMMIT_ID=$(git log -1 --format=%H)
-          for file in ${{ steps.artifact.outputs.base_artifact_name }} ${{ steps.artifact.outputs.jupyter_artifact_name }} ${{ steps.artifact.outputs.kyuubi_artifact_name }}; do
-              echo "Processing ${file}"
-              rockcraft.skopeo copy "oci-archive:${file}" oci:to_process:latest
-              regctl image mod ocidir://to_process:latest --replace \
-                --label "org.opencontainers.image.revision=${COMMIT_ID}" \
-                --label "org.opencontainers.image.source=${{ github.repositoryUrl }}"
-              regctl image export ocidir://to_process:latest "${file}"
-              rm -r to_process
-          done
+
+          FILE=${{ steps.artifact.outputs.base_artifact_name }}
+          echo "Processing ${FILE}"
+          rockcraft.skopeo copy "oci-archive:${FILE}" oci:to_process:latest
+          regctl image mod ocidir://to_process:latest --replace \
+            --label "org.opencontainers.image.revision=${COMMIT_ID}" \
+            --label "org.opencontainers.image.source=${{ github.repositoryUrl }}"
+          regctl image export ocidir://to_process:latest "${FILE}"
+          rm -r to_process
+
+          FILE=${{ steps.artifact.outputs.jupyter_artifact_name }}
+          DESCRIPTION=$(yq .flavours.jupyter.image_description images/metadata.yaml)
+          echo "Processing ${FILE}"
+          rockcraft.skopeo copy "oci-archive:${FILE}" oci:to_process:latest
+          regctl image mod ocidir://to_process:latest --replace \
+            --label "org.opencontainers.image.revision=${COMMIT_ID}" \
+            --label "org.opencontainers.image.source=${{ github.repositoryUrl }}" \
+            --label "org.opencontainers.image.description=${DESCRIPTION}"
+          regctl image export ocidir://to_process:latest "${FILE}"
+          rm -r to_process
+
+          FILE=${{ steps.artifact.outputs.kyuubi_artifact_name }}
+          DESCRIPTION=$(yq .flavours.kyuubi.image_description images/metadata.yaml)
+          echo "Processing ${FILE}"
+          rockcraft.skopeo copy "oci-archive:${FILE}" oci:to_process:latest
+          regctl image mod ocidir://to_process:latest --replace \
+            --label "org.opencontainers.image.revision=${COMMIT_ID}" \
+            --label "org.opencontainers.image.source=${{ github.repositoryUrl }}" \
+            --label "org.opencontainers.image.description=${DESCRIPTION}"
+          regctl image export ocidir://to_process:latest "${FILE}"
 
       - name: Upload locally built artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build_gpu.yaml
+++ b/.github/workflows/build_gpu.yaml
@@ -7,9 +7,6 @@ on:
         type: string
         default: "amd64"
         required: true
-      export-test-image:
-        type: boolean
-        default: false
 
 jobs:
   build:
@@ -53,9 +50,10 @@ jobs:
         run: |
           sudo snap install yq
           sudo snap install rockcraft --classic
+          sudo snap install regclient
 
       - name: Build image (GPU)
-        run: sudo make build FLAVOUR=gpu
+        run: make build FLAVOUR=gpu
 
       - name: Get Artifact Name
         id: artifact
@@ -63,8 +61,21 @@ jobs:
           GPU_ARTIFACT=$(make help FLAVOUR=gpu | grep 'Artifact: ')
           echo "gpu_artifact_name=${GPU_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
 
-      - name: Change artifact permissions
-        run: sudo chmod a+r  ${{ steps.artifact.outputs.gpu_artifact_name }}
+      - name: Add additional labels
+        run: |
+          COMMIT_ID=$(git log -1 --format=%H)
+          SPARK_VERSION=$(yq .version images/charmed-spark-gpu/rockcraft.yaml)
+          GPU_VERSION=$(yq .flavours.gpu.version images/metadata.yaml)
+
+
+          rockcraft.skopeo copy "oci-archive:${{ steps.artifact.outputs.gpu_artifact_name }}" oci:to_process:latest
+          regctl image mod ocidir://to_process:latest --replace \
+            --label "org.opencontainers.image.revision=${COMMIT_ID}" \
+            --label "org.opencontainers.image.source=${{ github.repositoryUrl }}"
+          regctl image export ocidir://to_process:latest \
+            --name "ghcr.io/canonical/test-charmed-spark-gpu:${SPARK_VERSION}-${GPU_VERSION}" \
+            "${{ steps.artifact.outputs.gpu_artifact_name }}"
+          rm -r to_process
 
       - name: Upload locally built artifact
         uses: actions/upload-artifact@v6
@@ -72,27 +83,3 @@ jobs:
           name: charmed-spark-gpu-${{ inputs.arch }}
           path: |
             ${{ steps.artifact.outputs.gpu_artifact_name }}
-
-      - name: Export test image
-        if: ${{ inputs.export-test-image }}
-        run: |
-          export SPARK_VERSION=$(yq .version images/charmed-spark-gpu/rockcraft.yaml)
-          export GPU_VERSION=$(yq .flavours.gpu.version images/metadata.yaml)
-
-          sudo snap install regclient
-          sudo docker run -d -p 5000:5000 --restart always --name local-registry registry:latest
-          rockcraft.skopeo --insecure-policy copy \
-            oci-archive:${{ steps.artifact.outputs.gpu_artifact_name }} \
-            "docker://localhost:5000/ghcr.io/canonical/test-charmed-spark-gpu:${SPARK_VERSION}-${GPU_VERSION}" \
-            --dest-tls-verify=false
-          regctl image export \
-            "localhost:5000/ghcr.io/canonical/test-charmed-spark-gpu:${SPARK_VERSION}-${GPU_VERSION}" \
-            --name "ghcr.io/canonical/test-charmed-spark-gpu:${SPARK_VERSION}-${GPU_VERSION}" \
-            --host reg=localhost:5000,tls=disabled >test_image.tar
-
-      - name: Upload test artifact
-        if: ${{ inputs.export-test-image }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: charmed-spark-gpu-test-${{ inputs.arch }}
-          path: test_image.tar

--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -13,7 +13,6 @@ jobs:
     uses: ./.github/workflows/build_gpu.yaml
     with:
       arch: ${{ inputs.arch }}
-      export-test-image: true
 
   start-runner:
     name: Start self-hosted EC2 runner
@@ -113,13 +112,13 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v7
         with:
-          name: charmed-spark-gpu-test-${{ inputs.arch }}
+          name: charmed-spark-gpu-${{ inputs.arch }}
           path: charmed-spark
 
       - name: Load test image
         run: |
           sudo mkdir /var/snap/k8s/common/images
-          sudo cp charmed-spark/test_image.tar /var/snap/k8s/common/images/
+          sudo cp charmed-spark/*.tar /var/snap/k8s/common/images/
           sudo snap restart k8s.containerd
           sleep 30
           if [ -z "$(sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --namespace k8s.io images list -q | grep test-charmed-spark)" ]; then


### PR DESCRIPTION
This PR adds back the additional labels that did not make the cut while adding arm64 support.

Since we already had a use for `regclient` (needed to import an image into Canonical K8s for the GPU tests), I reused it to add the label instead of the previous solution we had (rebuilding an image with additional labels using docker).

As the tar files now all come from a `regclient` export, we no longer need dedicated test artifacts and could streamline the GPU workflows.


When we `skopeo inspect` the Kyuubi image built by the CI here, we get

```
{
    "Digest": "sha256:aa282b18ab13e4a73ab4ad76ab9bdfee999c98293763c7a022f24e954cdf16a3",
    "RepoTags": [],
    "Created": "2026-03-13T15:44:26.836595208Z",
    "DockerVersion": "",
    "Labels": {
        "org.opencontainers.image.base.digest": "dfceaf45ec0029c0032d3c6f68cd428777658bed8d8e6d5cf7ded4f7e890052f",
        "org.opencontainers.image.created": "2026-03-13T15:42:52.478430+00:00",
        "org.opencontainers.image.description": "This is an OCI image that contains Kyuubi, fully integrated with Charmed\nSpark ecosystem and utilities.",
        "org.opencontainers.image.licenses": "Apache-2.0",
        "org.opencontainers.image.revision": "c7a34eeb3ea76412768eed3d9dd769e8f9623b45",
        "org.opencontainers.image.source": "git://github.com/canonical/charmed-spark-rock.git",
        "org.opencontainers.image.title": "charmed-spark",
        "org.opencontainers.image.version": "3.5.7"
    },
 
```

The description has been updated to  Kyuubi's, we have the git commit SHA under `revision` and the repo url.



The build job is no that different anymore between the GPU flavor and the rest, so we could regroup everything in one workflow. I kept it separated for now because we can run the GPU integration tests faster that way.