### PR TITLE
[MISC] Remove create-tags argument in release workflow (3.4)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,10 +115,10 @@ jobs:
       - name: Upload & release rocks
         id: release
         run: |
-          release-rock --directory=to_export/charmed-spark/ --create-tags=true
-          release-rock --directory=to_export/charmed-spark-kyuubi/ --create-tags=true
-          release-rock --directory=to_export/charmed-spark-jupyterlab/ --create-tags=true
-          release-rock --directory=to_export/charmed-spark-gpu/ --create-tags=true
+          release-rock --directory=to_export/charmed-spark/
+          release-rock --directory=to_export/charmed-spark-kyuubi/
+          release-rock --directory=to_export/charmed-spark-jupyterlab/
+          release-rock --directory=to_export/charmed-spark-gpu/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The `release-rock` utility recently removed this argument on the main branch.