### PR TITLE
[PRA-331] Add .trivyignore

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -59,6 +59,7 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "MEDIUM,HIGH,CRITICAL"
+          trivyignores: .trivyignore
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Addressed by spark-3.4.4-ubuntu10
+CVE-2025-54920


### PR DESCRIPTION
This PR adds the setup to disregard CVEs in the trivy scan step, such as the history-server vulnerability patch by spark-3.4.4-ubuntu10.

This PR no longer reports the history server vuln: https://github.com/canonical/charmed-spark-rock/security/code-scanning?query=history+pr%3A252+tool%3ATrivy+

Compared to 3.4/edge: https://github.com/canonical/charmed-spark-rock/security/code-scanning?query=history+branch%3A3.4%2Fedge+tool%3ATrivy+