### PR TITLE
[BACKPORT][PRA-331] Add .trivyignore (3.5)

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -59,6 +59,7 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "MEDIUM,HIGH,CRITICAL"
+          trivyignores: .trivyignore
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Backport #252 

While we don't have CVEs to suppress like in 3.4 yet, let's backport the setup for consistency between branches