### PR TITLE
[PRA-355] Fix trivy.yaml permissions

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -23,9 +23,6 @@ jobs:
     needs: build
     if: always()
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
     strategy:
       matrix:
         flavour:


### PR DESCRIPTION
This PR "re-backports" the tiny fix we brought in the backports PRs on 3.5 and 4.0 so that we can upload the sbom on release