### PR TITLE
[MISC] Enable Renovate on 4.0/edge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,8 @@
   // Between 1AM and 6:59AM, first Friday of the month
   schedule: ["* 1-6 1-7 * 5"],
   ignoreDeps: ["ubuntu"],
-  baseBranchPatterns: ["/^3\\..*\\/edge$/"],
+  baseBranchPatterns: ["/^3\\..*\\/edge$/", "/^4\\..*\\/edge$/"],
+  useBaseBranchConfig: "merge",
   enabledManagers: ["github-actions", "custom.regex"],
   commitMessagePrefix: "[RENOVATE] ",
   lockFileMaintenance: { enabled: false },


### PR DESCRIPTION
We were not running renovate on 4.0/edge, as the trigger is only picked from the default branch. We added `useBaseBranchConfig: "merge"` in case we want to override stuff on other branches as well